### PR TITLE
Frontend add "Progress" button for dashboard in 9 languages

### DIFF
--- a/docs-web/src/main/webapp/src/index.html
+++ b/docs-web/src/main/webapp/src/index.html
@@ -144,6 +144,9 @@
           <li ui-sref-active="{ active: 'user.**', active2: 'group.**' }">
             <a href="#/user"><span class="fas fa-user"></span> {{ 'index.nav_users_groups' | translate }}</a>
           </li>
+          <li ui-sref-active="{ active: 'progress.**'}" id="progress-tag">
+            <a href="#/progress"><span class="fas fa-progress"></span> {{ 'index.nav_progress' | translate }}</a>
+          </li>
         </ul>
 
         <ul class="nav navbar-nav navbar-right" ng-show="!userInfo.anonymous">

--- a/docs-web/src/main/webapp/src/locale/el.json
+++ b/docs-web/src/main/webapp/src/locale/el.json
@@ -29,7 +29,7 @@
   },
   "index": {
     "toggle_navigation": "Μετακίνηση πλοήγησης",
-    "nav_documents": "έγγραφα",
+    "nav_documents": "πρόοδος",
     "nav_tags": "Ετικέτες",
     "nav_users_groups": "Χρήστες & Ομάδες",
     "error_info": "{{ count }} Νέο σφάλμα",

--- a/docs-web/src/main/webapp/src/locale/el.json
+++ b/docs-web/src/main/webapp/src/locale/el.json
@@ -29,7 +29,8 @@
   },
   "index": {
     "toggle_navigation": "Μετακίνηση πλοήγησης",
-    "nav_documents": "πρόοδος",
+    "nav_documents": "έγγραφα",
+    "nav_progress": "πρόοδος",
     "nav_tags": "Ετικέτες",
     "nav_users_groups": "Χρήστες & Ομάδες",
     "error_info": "{{ count }} Νέο σφάλμα",

--- a/docs-web/src/main/webapp/src/locale/en.json
+++ b/docs-web/src/main/webapp/src/locale/en.json
@@ -32,6 +32,7 @@
     "nav_documents": "Documents",
     "nav_tags": "Tags",
     "nav_users_groups": "Users & Groups",
+    "nav_progress": "Progress",
     "error_info": "{{ count }} new error{{ count > 1 ? 's' : '' }}",
     "logged_as": "Logged in as {{ username }}",
     "nav_settings": "Settings",

--- a/docs-web/src/main/webapp/src/locale/es.json
+++ b/docs-web/src/main/webapp/src/locale/es.json
@@ -32,6 +32,7 @@
     "nav_documents": "Documentos",
     "nav_tags": "Etiquetas",
     "nav_users_groups": "Usuarios y Grupos",
+    "nav_progress": "Progreso",
     "error_info": "{{ count }} nuevo error{{ count > 1 ? 's' : '' }}",
     "logged_as": "Sesión iniciada como {{ username }}",
     "nav_settings": "Ajustes",

--- a/docs-web/src/main/webapp/src/locale/fr.json
+++ b/docs-web/src/main/webapp/src/locale/fr.json
@@ -32,6 +32,7 @@
     "nav_documents": "Documents",
     "nav_tags": "Tags",
     "nav_users_groups": "Utilisateurs & Groupes",
+    "nav_progress": "Progrès",
     "error_info": "{{ count }} nouvelle{{ count > 1 ? 's' : '' }} erreur{{ count > 1 ? 's' : '' }}",
     "logged_as": "Connecté en tant que {{ username }}",
     "nav_settings": "Paramètres",

--- a/docs-web/src/main/webapp/src/locale/it.json
+++ b/docs-web/src/main/webapp/src/locale/it.json
@@ -32,6 +32,7 @@
     "nav_documents": "Documenti",
     "nav_tags": "Tags",
     "nav_users_groups": "Utenti & Gruppi",
+    "nav_progress": "Progresso",
     "error_info": "{{ count }} nuov{{ count > 1 ? 'i' : 'o' }} error{{ count > 1 ? 'i' : 'e' }}",
     "logged_as": "Effettuato l'accesso come {{ username }}",
     "nav_settings": "Impostazioni",

--- a/docs-web/src/main/webapp/src/locale/pl.json
+++ b/docs-web/src/main/webapp/src/locale/pl.json
@@ -32,6 +32,7 @@
     "nav_documents": "Dokumenty",
     "nav_tags": "Etykiety",
     "nav_users_groups": "Użytkownicy i Grupy",
+    "nav_progress": "Postęp",
     "error_info": "{{ count }} nowe błędy",
     "logged_as": "Zalogowany jako {{ username }}",
     "nav_settings": "Ustawienia",

--- a/docs-web/src/main/webapp/src/locale/ru.json
+++ b/docs-web/src/main/webapp/src/locale/ru.json
@@ -32,6 +32,7 @@
     "nav_documents": "Документы",
     "nav_tags": "Теги",
     "nav_users_groups": "Пользователи и группы",
+    "nav_progress": "прогресс",
     "error_info": "{{ count }} новая ошибка",
     "logged_as": "Вы вошли как {{ username }}",
     "nav_settings": "Настройки",

--- a/docs-web/src/main/webapp/src/locale/zh_CN.json
+++ b/docs-web/src/main/webapp/src/locale/zh_CN.json
@@ -32,6 +32,7 @@
     "nav_documents": "文档",
     "nav_tags": "标签",
     "nav_users_groups": "用户 & 群组",
+    "nav_progress": "進步",
     "error_info": "{{ count }} 新错误",
     "logged_as": "以 {{ username }}登录",
     "nav_settings": "设置",

--- a/docs-web/src/main/webapp/src/locale/zh_TW.json
+++ b/docs-web/src/main/webapp/src/locale/zh_TW.json
@@ -32,6 +32,7 @@
     "nav_documents": "文檔",
     "nav_tags": "標籤",
     "nav_users_groups": "用戶 & 群組",
+    "nav_progress": "進步",
     "error_info": "{{ count }} 新錯誤",
     "logged_as": "以 {{ username }}登錄",
     "nav_settings": "設置",


### PR DESCRIPTION
Frontend changes for Issue #7 
New tab for page called Progress to link to our dashboard
Translates to Chinese, French, Russian, English, Polish, Spanish, Italian, Greek, etc.